### PR TITLE
tmp pattern_path fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
+# 2.0.5
+  - Temporary specs fix, see https://github.com/logstash-plugins/logstash-input-syslog/pull/25
 # 2.0.4
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
 # 2.0.3
   - New dependency requirements for logstash-core for the 5.0 release
 ## 2.0.0
- - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
+ - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully,
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895
  - Dependency on logstash-core update to 2.0
 

--- a/logstash-input-syslog.gemspec
+++ b/logstash-input-syslog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-syslog'
-  s.version         = '2.0.4'
+  s.version         = '2.0.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read syslog messages as events over the network."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/syslog_spec.rb
+++ b/spec/inputs/syslog_spec.rb
@@ -8,6 +8,19 @@ unless LogStash::Environment.const_defined?(:LOGSTASH_HOME)
   LogStash::Environment::LOGSTASH_HOME = File.expand_path("../../", __FILE__)
 end
 
+# temporary fix to have the spec pass for an urgen mass-publish requirement.
+# cut & pasted from the same tmp fix in the grok spec
+# see https://github.com/logstash-plugins/logstash-filter-grok/issues/72
+# this needs to be refactored and properly fixed
+module LogStash::Environment
+  # also :pattern_path method must exist so we define it too
+  unless self.method_defined?(:pattern_path)
+    def pattern_path(path)
+      ::File.join(LOGSTASH_HOME, "patterns", path)
+    end
+  end
+end
+
 require "logstash/inputs/syslog"
 require "logstash/event"
 require "stud/try"


### PR DESCRIPTION
temporary fix to have the spec pass for an urgen mass-publish requirement.
relates to logstash-plugins/logstash-filter-grok#72