### PR TITLE
Add feature to disable tag on parse failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0
+  - Add config option to disable tagging parse failures. Default is to always tag on non-complaint 
+    syslog data.
+
 ## 3.2.0
   - Add support for proxy protocol.
 

--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -66,6 +66,10 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
   # weekday names (pattern with EEE).
   #
   config :locale, :validate => :string
+  # If the input is not RFC 5424 compliant, the default behavior is to create a tag which notifies 
+  # user this happened. This option exists to supress creating the tag when a user knows they are 
+  # already sending non compliant syslog data.
+  config :tag_on_parse_failure, :validate => :boolean, :default => true
 
   public
   def initialize(params)
@@ -80,7 +84,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     @grok_filter = LogStash::Filters::Grok.new(
       "overwrite" => "message",
       "match" => { "message" => "<%{POSINT:priority}>%{SYSLOGLINE}" },
-      "tag_on_failure" => ["_grokparsefailure_sysloginput"],
+      "tag_on_failure" => (tag_on_parse_failure ? "_grokparsefailure_sysloginput" : [])
     )
 
     @date_filter = LogStash::Filters::Date.new(

--- a/logstash-input-syslog.gemspec
+++ b/logstash-input-syslog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-syslog'
-  s.version         = '3.2.0'
+  s.version         = '3.3.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read syslog messages as events over the network."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The default behavior is not affected and will tag on any event that is not
compliant with RFC3164