### PR TITLE
Bump UDP recvfrom maxlen value to 65507

### DIFF
--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -141,7 +141,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     @udp.bind(@host, @port)
 
     while !stop?
-      payload, client = @udp.recvfrom(9000)
+      payload, client = @udp.recvfrom(65507)
       metric.increment(:messages_received)
       decode(client[3], output_queue, payload)
     end


### PR DESCRIPTION
Increase the max length value passed to UDP's socket recvfrom method to 65,507 bytes, that is the max message length of the data in a UDP datagram.