### PR TITLE
Fix: errors on shutdown & reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.4
+  - Fix issue where stopping a pipeline (e.g., while reloading configuration) with active inbound syslog connections could cause Logstash to crash
+
 ## 3.2.3
   - Update gemspec summary
 

--- a/logstash-input-syslog.gemspec
+++ b/logstash-input-syslog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-syslog'
-  s.version         = '3.2.3'
+  s.version         = '3.2.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads syslog messages as events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
When an open connection is closed, an exception is raised; depending on timing
and internal details of `Socket#each`, this is one of two exceptions:

 - `IOError` (closed stream): when `Socket#each` advances after emitting an
   event, it checks to see if the socket is already closed, and emits this
   exception with a message `"closed stream"` if so.
 - `Errno::EBADF` (Bad File Descriptor) - after checking the status of the
   stream and the underlying socket's file descriptor is cleaned up,
   subsequent reads will emit this exception.

In either case, log that the connection has closed and squash the exception,
allowing a graceful shutdown of the input.

Resolves: logstash-plugins/logstash-input-syslog#40