### PR TITLE
Permit the use of a custom grok pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.0
+  - Make the grok pattern a configurable option
+
 ## 3.2.4
   - Fix issue where stopping a pipeline (e.g., while reloading configuration) with active inbound syslog connections could cause Logstash to crash
 

--- a/NOTICE.TXT
+++ b/NOTICE.TXT
@@ -1,5 +1,5 @@
 Elasticsearch
-Copyright 2012-2015 Elasticsearch
+Copyright 2012-2018 Elasticsearch
 
 This product includes software developed by The Apache Software
 Foundation (http://www.apache.org/).

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -27,10 +27,11 @@ It is also a good choice if you want to receive logs from
 appliances and network devices where you cannot run your own
 log collector.
 
-Of course, 'syslog' is a very muddy term. This input only supports `RFC3164`
-syslog with some small modifications. The date format is allowed to be
-`RFC3164` style or `ISO8601`. Otherwise the rest of `RFC3164` must be obeyed.
-If you do not use `RFC3164`, do not use this input.
+Of course, 'syslog' is a very muddy term. By default, this input only
+supports `RFC3164` syslog with some small modifications. However, some
+non-standard syslog formats can be read and parsed if a functional
+`grok_pattern` is provided. The date format is still only allowed to be
+`RFC3164` style or `ISO8601`.
 
 For more information see the http://www.ietf.org/rfc/rfc3164.txt[RFC3164 page].
 
@@ -46,6 +47,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |=======================================================================
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-facility_labels>> |<<array,array>>|No
+| <<plugins-{type}s-{plugin}-grok_pattern>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-locale>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-port>> |<<number,number>>|No
@@ -61,15 +63,33 @@ input plugins.
 &nbsp;
 
 [id="plugins-{type}s-{plugin}-facility_labels"]
-===== `facility_labels` 
+===== `facility_labels`
 
   * Value type is <<array,array>>
   * Default value is `["kernel", "user-level", "mail", "system", "security/authorization", "syslogd", "line printer", "network news", "UUCP", "clock", "security/authorization", "FTP", "NTP", "log audit", "log alert", "clock", "local0", "local1", "local2", "local3", "local4", "local5", "local6", "local7"]`
 
 Labels for facility levels. These are defined in RFC3164.
 
+[id="plugins-{type}s-{plugin}-grok_pattern"]
+===== `grok_pattern`
+
+  * Value type is <<string,string>>
+  * Default value is `"<%{POSINT:priority}>%{SYSLOGLINE}"`
+
+The default value should read and properly parse syslog lines which are
+fully compliant with http://www.ietf.org/rfc/rfc3164.txt[RFC3164].
+
+You can override this value to parse non-standard lines with a valid grok
+pattern which will parse the received lines.  If the line is unable to
+be parsed, the `_grokparsefailure_sysloginput` tag will be added.
+
+The grok pattern must provide a `timestamp` field. If the `timestamp`
+field is omitted, or is unable to be parsed as `RFC3164` style or
+`ISO8601`, a `_dateparsefailure` tag will be added.
+
+
 [id="plugins-{type}s-{plugin}-host"]
-===== `host` 
+===== `host`
 
   * Value type is <<string,string>>
   * Default value is `"0.0.0.0"`
@@ -77,7 +97,7 @@ Labels for facility levels. These are defined in RFC3164.
 The address to listen on.
 
 [id="plugins-{type}s-{plugin}-locale"]
-===== `locale` 
+===== `locale`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -91,7 +111,7 @@ weekday names (pattern with EEE).
 
 
 [id="plugins-{type}s-{plugin}-port"]
-===== `port` 
+===== `port`
 
   * Value type is <<number,number>>
   * Default value is `514`
@@ -100,7 +120,7 @@ The port to listen on. Remember that ports less than 1024 (privileged
 ports) may require root to use.
 
 [id="plugins-{type}s-{plugin}-proxy_protocol"]
-===== `proxy_protocol` 
+===== `proxy_protocol`
 
   * Value type is <<boolean,boolean>>
   * Default value is `false`
@@ -109,7 +129,7 @@ Proxy protocol support, only v1 is supported at this time
 http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt
 
 [id="plugins-{type}s-{plugin}-severity_labels"]
-===== `severity_labels` 
+===== `severity_labels`
 
   * Value type is <<array,array>>
   * Default value is `["Emergency", "Alert", "Critical", "Error", "Warning", "Notice", "Informational", "Debug"]`
@@ -117,7 +137,7 @@ http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt
 Labels for severity levels. These are defined in RFC3164.
 
 [id="plugins-{type}s-{plugin}-timezone"]
-===== `timezone` 
+===== `timezone`
 
   * Value type is <<string,string>>
   * There is no default value for this setting.
@@ -131,7 +151,7 @@ Canonical ID is good as it takes care of daylight saving time for you
 For example, `America/Los_Angeles` or `Europe/France` are valid IDs.
 
 [id="plugins-{type}s-{plugin}-use_labels"]
-===== `use_labels` 
+===== `use_labels`
 
   * Value type is <<boolean,boolean>>
   * Default value is `true`

--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -36,6 +36,10 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
   # ports) may require root to use.
   config :port, :validate => :number, :default => 514
 
+  # Set custom grok pattern to parse the syslog, in case the format differs
+  # from the defined standard.  This is common in security and other appliances
+  config :grok_pattern, :validate => :string, :default => "<%{POSINT:priority}>%{SYSLOGLINE}"
+
   # Proxy protocol support, only v1 is supported at this time
   # http://www.haproxy.org/download/1.5/doc/proxy-protocol.txt
   config :proxy_protocol, :validate => :boolean, :default => false
@@ -79,12 +83,12 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     require "thread_safe"
     @grok_filter = LogStash::Filters::Grok.new(
       "overwrite" => "message",
-      "match" => { "message" => "<%{POSINT:priority}>%{SYSLOGLINE}" },
+      "match" => { "message" => @grok_pattern },
       "tag_on_failure" => ["_grokparsefailure_sysloginput"],
     )
 
     @date_filter = LogStash::Filters::Date.new(
-      "match" => [ "timestamp", "MMM  d HH:mm:ss", "MMM dd HH:mm:ss", "ISO8601"],
+      "match" => [ "timestamp", "MMM dd HH:mm:ss", "MMM  d HH:mm:ss", "ISO8601"],
       "locale" => @locale,
       "timezone" => @timezone,
     )

--- a/logstash-input-syslog.gemspec
+++ b/logstash-input-syslog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-syslog'
-  s.version         = '3.2.4'
+  s.version         = '3.3.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads syslog messages as events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This allows the syslog input plugin to ingest events from appliances which send in non-standard syslog formats, especially when use of a codec (e.g. cef) is also required.  This prevents the need for custom plugins or hacks.

This exact scenario was encountered, where an appliance was sending "syslog" which was not RFC compliant, and the use of the cef codec was required to further parse the remaining portion of the message.