### PR TITLE
Change canonical ID : Europe/France

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -173,7 +173,7 @@ This is useful in case the time zone cannot be extracted from the value,
 and is not the platform default.
 If this is not specified the platform default will be used.
 Canonical ID is good as it takes care of daylight saving time for you
-For example, `America/Los_Angeles` or `Europe/France` are valid IDs.
+For example, `America/Los_Angeles` or `Europe/Paris` are valid IDs.
 
 [id="plugins-{type}s-{plugin}-use_labels"]
 ===== `use_labels`


### PR DESCRIPTION
Europe/France is not a valid ID and not present in http://joda-time.sourceforge.net/timezones.html .
Instead Europe/Paris is valid one for the same timezone.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
