### PR TITLE
allow to listen on IPv6 address

### DIFF
--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -145,7 +145,11 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     @logger.info("Starting syslog udp listener", :address => "#{@host}:#{@port}")
 
     @udp.close if @udp
-    @udp = UDPSocket.new(Socket::AF_INET)
+    if @host.include? ':'
+      @udp = UDPSocket.new(Socket::AF_INET6)
+    else
+      @udp = UDPSocket.new(Socket::AF_INET)
+    end
     @udp.bind(@host, @port)
 
     while !stop?


### PR DESCRIPTION
A quick and dirty fix to allow listen on IPv6 UDP, the assumption is that people specify `host` as an IP address, and `:` is valid (and must) char in IPv6, but the other way in IPv4.

There should be a better way to determine the address' family, but I'm not familiar with Ruby so tend to make smallest change. Also, there may be cases that people want to listen on both IPv6 and IPv4 addresses, which is not covered by this change though it's easy to tweak the code to do that.

EDIT: Tested in my env with IPv6 or IPv4, not both.