### PR TITLE
Feat: Support IPv6 UDP sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.5
+  - Added support for listening on IPv6 addresses
+
 ## 3.4.4
   - Refactor: avoid global side-effect + cleanup [#62](https://github.com/logstash-plugins/logstash-input-syslog/pull/62)
     * avoid setting `BasicSocket.do_not_reverse_lookup` as it has side effects for others 

--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -138,7 +138,11 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     @logger.info("Starting syslog udp listener", :address => "#{@host}:#{@port}")
 
     @udp.close if @udp
-    @udp = UDPSocket.new(Socket::AF_INET)
+    if IPAddr.new(@host).ipv6?
+      @udp = UDPSocket.new(Socket::AF_INET6)
+    elsif IPAddr.new(@host).ipv4?
+      @udp = UDPSocket.new(Socket::AF_INET)
+    end
     @udp.do_not_reverse_lookup = true
     @udp.bind(@host, @port)
 

--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -138,11 +138,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     @logger.info("Starting syslog udp listener", :address => "#{@host}:#{@port}")
 
     @udp.close if @udp
-    if IPAddr.new(@host).ipv6?
-      @udp = UDPSocket.new(Socket::AF_INET6)
-    elsif IPAddr.new(@host).ipv4?
-      @udp = UDPSocket.new(Socket::AF_INET)
-    end
+    @udp = UDPSocket.new (IPAddr.new(@host).ipv6? rescue nil) ? Socket::AF_INET6 : Socket::AF_INET
     @udp.do_not_reverse_lookup = true
     @udp.bind(@host, @port)
 

--- a/logstash-input-syslog.gemspec
+++ b/logstash-input-syslog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-syslog'
-  s.version         = '3.4.4'
+  s.version         = '3.4.5'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads syslog messages as events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
It seems that UDP isn't correctly binding to IPv6, this seems to be because ruby requires an UDP socket to have a specific INET variable set. This pull-request parses the listening IP-address and opens the correct variant of the UDP socket.