### PR TITLE
Refactor: avoid global side-effect + cleanup 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.4
+  - Refactor: avoid global side-effect + cleanup [#62](https://github.com/logstash-plugins/logstash-input-syslog/pull/62)
+    * avoid setting `BasicSocket.do_not_reverse_lookup` as it has side effects for others 
+
 ## 3.4.3
   - [DOC] Added expanded descriptions and requirements for facility_labels and severity_labels. [#52](https://github.com/logstash-plugins/logstash-input-syslog/pull/52)
 

--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -75,12 +75,6 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
   config :locale, :validate => :string
 
   public
-  def initialize(params)
-    super
-    BasicSocket.do_not_reverse_lookup = true
-  end # def initialize
-
-  public
   def register
     @metric_errors = metric.namespace(:errors)
 
@@ -145,6 +139,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
 
     @udp.close if @udp
     @udp = UDPSocket.new(Socket::AF_INET)
+    @udp.do_not_reverse_lookup = true
     @udp.bind(@host, @port)
 
     while !stop?
@@ -164,6 +159,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
   def tcp_listener(output_queue)
     @logger.info("Starting syslog tcp listener", :address => "#{@host}:#{@port}")
     @tcp = TCPServer.new(@host, @port)
+    @tcp.do_not_reverse_lookup = true
 
     while !stop?
       socket = @tcp.accept

--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -230,7 +230,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     end
   rescue => e
     # swallow and log all decoding exceptions, these will never be socket related
-    @logger.error("Error decoding data", :data => data.inspect, :exception => e, :backtrace => e.backtrace)
+    @logger.error("Error decoding data", :data => data.inspect, :exception => e.class, :message => e.message, :backtrace => e.backtrace)
     @metric_errors.increment(:decoding)
   end
 

--- a/logstash-input-syslog.gemspec
+++ b/logstash-input-syslog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-syslog'
-  s.version         = '3.4.3'
+  s.version         = '3.4.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads syslog messages as events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-syslog.gemspec
+++ b/logstash-input-syslog.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'logstash-filter-date'
 
   s.add_development_dependency 'logstash-devutils'
-  s.add_development_dependency 'insist'
   s.add_development_dependency 'logstash-codec-cef'
 end
 

--- a/spec/inputs/syslog_spec.rb
+++ b/spec/inputs/syslog_spec.rb
@@ -55,11 +55,11 @@ describe LogStash::Inputs::Syslog do
       event_count.times.collect { queue.pop }
     end
 
-    insist { events.length } == event_count
+    expect( events.length ).to eql event_count
     events.each do |event|
-      insist { event.get("priority") } == 164
-      insist { event.get("severity") } == 4
-      insist { event.get("facility") } == 20
+      expect( event.get("priority") ).to eql 164
+      expect( event.get("severity") ).to eql 4
+      expect( event.get("facility") ).to eql 20
     end
   end
 
@@ -89,12 +89,12 @@ describe LogStash::Inputs::Syslog do
       event_count.times.collect { queue.pop }
     end
 
-    insist { events.length } == event_count
+    expect( events.length ).to eql event_count
     events.each do |event|
-      insist { event.get("priority") } == 164
-      insist { event.get("severity") } == 4
-      insist { event.get("facility") } == 20
-      insist { event.get("host") } == "1.2.3.4"
+      expect( event.get("priority") ).to eql 164
+      expect( event.get("severity") ).to eql 4
+      expect( event.get("facility") ).to eql 20
+      expect( event.get("host") ).to eql "1.2.3.4"
     end
   end
 
@@ -121,9 +121,9 @@ describe LogStash::Inputs::Syslog do
       event_count.times.collect { queue.pop }
     end
 
-    insist { events.length } == event_count
+    expect( events.length ).to eql event_count
     event_count.times do |i|
-      insist { events[i].get("tags") } == ["_grokparsefailure_sysloginput"]
+      expect( events[i].get("tags") ).to eql ["_grokparsefailure_sysloginput"]
     end
   end
 
@@ -152,9 +152,9 @@ describe LogStash::Inputs::Syslog do
       event_count.times.collect { queue.pop }
     end
 
-    insist { events.length } == event_count
+    expect( events.length ).to eql event_count
     events.each do |event|
-      insist { event.get("@timestamp").to_iso8601 } == "#{Time.now.year}-10-26T15:19:25.000Z"
+      expect( event.get("@timestamp").to_iso8601 ).to eql "#{Time.now.year}-10-26T15:19:25.000Z"
     end
   end
 
@@ -179,7 +179,7 @@ describe LogStash::Inputs::Syslog do
     end
 
     # chances platform timezone is not UTC so ignore the hours
-    insist { event.get("@timestamp").to_iso8601 } =~ /#{Time.now.year}-10-26T\d\d:19:25.000Z/
+    expect( event.get("@timestamp").to_iso8601 ).to match /#{Time.now.year}-10-26T\d\d:19:25.000Z/
   end
 
   it "should support non UTC timezone" do
@@ -190,7 +190,7 @@ describe LogStash::Inputs::Syslog do
 
     syslog_event = LogStash::Event.new({ "message" => "<164>Oct 26 15:19:25 1.2.3.4 %ASA-4-106023: Deny udp src DRAC:10.1.2.3/43434" })
     input.syslog_relay(syslog_event)
-    insist { syslog_event.get("@timestamp").to_iso8601 } == "#{Time.now.year}-10-26T20:19:25.000Z"
+    expect( syslog_event.get("@timestamp").to_iso8601 ).to eql "#{Time.now.year}-10-26T20:19:25.000Z"
 
     input.close
   end
@@ -202,13 +202,13 @@ describe LogStash::Inputs::Syslog do
     # event which is not syslog should have a new tag
     event = LogStash::Event.new({ "message" => "hello world, this is not syslog RFC3164" })
     input.syslog_relay(event)
-    insist { event.get("tags") } ==  ["_grokparsefailure_sysloginput"]
+    expect( event.get("tags") ).to eql  ["_grokparsefailure_sysloginput"]
 
     syslog_event = LogStash::Event.new({ "message" => "<164>Oct 26 15:19:25 1.2.3.4 %ASA-4-106023: Deny udp src DRAC:10.1.2.3/43434" })
     input.syslog_relay(syslog_event)
-    insist { syslog_event.get("priority") } ==  164
-    insist { syslog_event.get("severity") } ==  4
-    insist { syslog_event.get("tags") } ==  nil
+    expect( syslog_event.get("priority") ).to eql 164
+    expect( syslog_event.get("severity") ).to eql 4
+    expect( syslog_event.get("tags") ).to be nil
 
     input.close
   end
@@ -245,13 +245,13 @@ describe LogStash::Inputs::Syslog do
       event_count.times.collect { queue.pop }
     end
 
-    insist { events.length } == event_count
+    expect( events.length ).to eql event_count
     events.each do |event|
-      insist { event.get("priority")  } == 164
-      insist { event.get("severity")  } == 4
-      insist { event.get("facility")  } == 20
-      insist { event.get("message")   } == "#{message_field}\n"
-      insist { event.get("timestamp") } == timestamp
+      expect( event.get("priority") ).to eql 164
+      expect( event.get("severity") ).to eql 4
+      expect( event.get("facility") ).to eql 20
+      expect( event.get("message") ).to eql "#{message_field}\n"
+      expect( event.get("timestamp") ).to eql timestamp
     end
   end
 
@@ -284,13 +284,13 @@ describe LogStash::Inputs::Syslog do
       event_count.times.collect { queue.pop }
     end
 
-    insist { events.length } == event_count
+    expect( events.length ).to eql event_count
     events.each do |event|
-      insist { event.get("priority")  } == 134
-      insist { event.get("severity")  } == 6
-      insist { event.get("facility")  } == 16
-      insist { event.get("message")   } == message_field
-      insist { event.get("timestamp") } == timestamp
+      expect( event.get("priority") ).to eql 134
+      expect( event.get("severity") ).to eql 6
+      expect( event.get("facility") ).to eql 16
+      expect( event.get("message") ).to eql message_field
+      expect( event.get("timestamp") ).to eql timestamp
     end
   end
 end

--- a/spec/inputs/syslog_spec.rb
+++ b/spec/inputs/syslog_spec.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require "logstash/devutils/rspec/spec_helper"
-require "insist"
 require "logstash/devutils/rspec/shared_examples"
 
 # running the grok code outside a logstash package means


### PR DESCRIPTION
had the insist gem removal lying around, besides there's 2 notable changes:
- avoid `BasicSocket.do_not_reverse_lookup` as it has side effects for others
- normalize logging + do not degrade performance when debug logging exceptions due `caller` use
  (the place of exception will still be identifiable, with debug logging, from an added label)
