### PR TITLE
Feat: ECS compatibility support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.5.0
+  - Feat: ECS compatibility support [#63](https://github.com/logstash-plugins/logstash-input-syslog/pull/63)
+
 ## 3.4.5
   - Added support for listening on IPv6 addresses
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -47,6 +47,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 [cols="<,<,<",options="header",]
 |=======================================================================
 |Setting |Input type|Required
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> | <<string,string>>|No
 | <<plugins-{type}s-{plugin}-facility_labels>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-grok_pattern>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-host>> |<<string,string>>|No
@@ -63,6 +64,23 @@ Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options suppo
 input plugins.
 
 &nbsp;
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: does not provide ECS-compatible templates
+    ** `v1`: provides defaults that are compatible with v1 of the Elastic Common Schema
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}}[Elastic Common Schema (ECS)].
+The value of this setting affects the _default_ values of:
+
+* <<plugins-{type}s-{plugin}-grok_pattern>>
+
 
 [id="plugins-{type}s-{plugin}-facility_labels"]
 ===== `facility_labels`
@@ -84,6 +102,9 @@ the facility_label is not added to the event.
 
   * Value type is <<string,string>>
   * Default value is `"<%{POSINT:priority}>%{SYSLOGLINE}"`
+  * Default value depends on whether <<plugins-{type}s-{plugin}-ecs_compatibility>> is enabled:
+    ** ECS Compatibility disabled: `"<%{POSINT:priority}>%{SYSLOGLINE}"`
+    ** ECS Compatibility enabled: `"<%{POSINT:[log][syslog][priority]:int}>%{SYSLOGLINE}"`
 
 The default value should read and properly parse syslog lines which are
 fully compliant with http://www.ietf.org/rfc/rfc3164.txt[RFC3164].

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -70,14 +70,14 @@ input plugins.
 
   * Value type is <<string,string>>
   * Supported values are:
-    ** `disabled`: does not use ECS-compatible field names (e.g. `priority` for syslog priority)
-    ** `v1`: uses fields that are compatible with Elastic Common Schema (e.g. `[log][syslog][priority]`)
+    ** `disabled`: does not use ECS-compatible field names (for example, `priority` for syslog priority)
+    ** `v1`: uses fields that are compatible with Elastic Common Schema (for example, `[log][syslog][priority]`)
   * Default value depends on which version of Logstash is running:
     ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
     ** Otherwise, the default value is `disabled`.
 
 Controls this plugin's compatibility with the
-https://www.elastic.co/guide/en/ecs/current/index.html[Elastic Common Schema (ECS)].
+{ecs-ref}[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-facility_labels"]
 ===== `facility_labels`

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -70,17 +70,14 @@ input plugins.
 
   * Value type is <<string,string>>
   * Supported values are:
-    ** `disabled`: does not provide ECS-compatible templates
-    ** `v1`: provides defaults that are compatible with v1 of the Elastic Common Schema
+    ** `disabled`: does not use ECS-compatible field names (e.g. `priority` for syslog priority)
+    ** `v1`: uses fields that are compatible with Elastic Common Schema (e.g. `[log][syslog][priority]`)
   * Default value depends on which version of Logstash is running:
     ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
     ** Otherwise, the default value is `disabled`.
 
-Controls this plugin's compatibility with the {ecs-ref}}[Elastic Common Schema (ECS)].
-The value of this setting affects the _default_ values of:
-
-* <<plugins-{type}s-{plugin}-grok_pattern>>
-
+Controls this plugin's compatibility with the
+https://www.elastic.co/guide/en/ecs/current/index.html[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-facility_labels"]
 ===== `facility_labels`

--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -104,7 +104,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     @grok_filter_exec = ecs_select[
         disabled: -> (event) { @grok_filter.filter(event) },
         v1: -> (event) {
-          event.set('[event][original]', @syslog_field)
+          event.set('[event][original]', event.get(@syslog_field))
           @grok_filter.filter(event)
         }
     ]

--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -314,10 +314,8 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
 
       # in legacy (non-ecs) mode we used to match (SYSLOGBASE2) timestamp into two fields
       event.set("timestamp", event.get("timestamp8601")) if event.include?("timestamp8601")
-      if event.include?("timestamp")
-        @date_filter.filter(event)
-        event.remove 'timestamp' if ecs_compatibility_enabled?
-      end
+      @date_filter.filter(event)
+      event.remove 'timestamp' if ecs_compatibility_enabled?
     else
       @logger.debug? && @logger.debug("un-matched syslog message", :message => event.get("message"))
 

--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -87,7 +87,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     @facility_label_key = ecs_select[disabled:'facility_label', v1:'[log][syslog][facility][name]']
     @severity_label_key = ecs_select[disabled:'severity_label', v1:'[log][syslog][severity][name]']
 
-    @source_key = ecs_select[disabled:'host', v1:'[source][ip]']
+    @host_key = ecs_select[disabled:'host', v1:'[host][ip]']
 
     @grok_pattern ||= ecs_select[
         disabled:"<%{POSINT:#{@priority_key}}>%{SYSLOGLINE}",
@@ -255,10 +255,10 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
     socket.close rescue log_and_squash(:close_tcp_receiver_socket)
   end
 
-  def decode(host, output_queue, data)
+  def decode(ip, output_queue, data)
     @codec.decode(data) do |event|
       decorate(event)
-      event.set(@source_key, host) # do we also want to capture source.port ?
+      event.set(@host_key, ip)
       syslog_relay(event)
       output_queue << event
       metric.increment(:events)

--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -240,10 +240,10 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
   rescue Errno::EBADF
     # swallow connection closed exceptions to avoid bubling up the tcp_listener & server
     logger.info("connection closed", :client => "#{ip}:#{port}")
-  rescue IOError => ioerror
+  rescue IOError => e
     # swallow connection closed exceptions to avoid bubling up the tcp_listener & server
-    raise unless socket.closed? && ioerror.message.include?("closed")
-    logger.info("connection error: #{ioerror.message}")
+    raise(e) unless socket.closed? && e.message.to_s.include?("closed")
+    logger.info("connection error:", :exception => e.class, :message => e.message)
   ensure
     @tcp_sockets.delete(socket)
     socket.close rescue log_and_squash(:close_tcp_receiver_socket)

--- a/lib/logstash/inputs/syslog.rb
+++ b/lib/logstash/inputs/syslog.rb
@@ -312,7 +312,7 @@ class LogStash::Inputs::Syslog < LogStash::Inputs::Base
         event.remove 'timestamp' if ecs_compatibility_enabled?
       end
     else
-      @logger.debug? && @logger.debug("NOT SYSLOG", :message => event.get("message"))
+      @logger.debug? && @logger.debug("un-matched syslog message", :message => event.get("message"))
 
       # RFC3164 says unknown messages get pri=13
       set_priority event, 13

--- a/logstash-input-syslog.gemspec
+++ b/logstash-input-syslog.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'
 
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'logstash-filter-grok'
+  s.add_runtime_dependency 'logstash-filter-grok', '>= 4.4.0'
   s.add_runtime_dependency 'logstash-filter-date'
 
   s.add_development_dependency 'logstash-devutils'

--- a/logstash-input-syslog.gemspec
+++ b/logstash-input-syslog.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.0'
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.1'
 
   s.add_runtime_dependency 'concurrent-ruby'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'

--- a/logstash-input-syslog.gemspec
+++ b/logstash-input-syslog.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.0'
 
   s.add_runtime_dependency 'concurrent-ruby'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1.0'

--- a/logstash-input-syslog.gemspec
+++ b/logstash-input-syslog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-syslog'
-  s.version         = '3.4.5'
+  s.version         = '3.5.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads syslog messages as events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/syslog_spec.rb
+++ b/spec/inputs/syslog_spec.rb
@@ -259,6 +259,12 @@ describe LogStash::Inputs::Syslog do
         expect( event.get('log') ).to include 'syslog' => hash_including('severity' => { 'code' => 4, 'name' => 'Warning' })
       end
 
+      it "sets service type" do
+        subject.syslog_relay(event)
+
+        expect( event.get('service') ).to include 'type' => 'system'
+      end
+
       let(:queue) { Queue.new }
 
       let(:socket) do

--- a/spec/inputs/syslog_spec.rb
+++ b/spec/inputs/syslog_spec.rb
@@ -32,7 +32,7 @@ describe LogStash::Inputs::Syslog do
   SYSLOG_LINE = "<164>Oct 26 15:19:25 1.2.3.4 %ASA-4-106023: Deny udp src DRAC:10.1.2.3/43434 dst outside:192.168.0.1/53 by access-group \"acl_drac\" [0x0, 0x0]"
 
   it "should properly handle priority, severity and facilities" do
-    skip 'elastic/logstash#11196 known LS 7.5 issue' if ENV['ELASTIC_STACK_VERSION'] && JRUBY_VERSION.eql?('9.2.8.0')
+    skip_if_stack_known_issue
     port = 5511
     event_count = 10
     conf = <<-CONFIG
@@ -63,7 +63,7 @@ describe LogStash::Inputs::Syslog do
   end
 
   it "should properly PROXY protocol v1" do
-    skip 'elastic/logstash#11196 known LS 7.5 issue' if ENV['ELASTIC_STACK_VERSION'] && JRUBY_VERSION.eql?('9.2.8.0')
+    skip_if_stack_known_issue
     port = 5511
     event_count = 10
     conf = <<-CONFIG
@@ -98,7 +98,7 @@ describe LogStash::Inputs::Syslog do
   end
 
   it "should add unique tag when grok parsing fails with live syslog input" do
-    skip 'elastic/logstash#11196 known LS 7.5 issue' if ENV['ELASTIC_STACK_VERSION'] && JRUBY_VERSION.eql?('9.2.8.0')
+    skip_if_stack_known_issue
     port = 5511
     event_count = 10
     conf = <<-CONFIG
@@ -291,5 +291,11 @@ describe LogStash::Inputs::Syslog do
       expect( event.get("message") ).to eql message_field
       expect( event.get("timestamp") ).to eql timestamp
     end
+  end
+
+  private
+
+  def skip_if_stack_known_issue
+    skip 'elastic/logstash#11196 known LS 7.5 issue' if ENV['ELASTIC_STACK_VERSION'] && JRUBY_VERSION.eql?('9.2.8.0')
   end
 end


### PR DESCRIPTION
**Support for Elastic Common Schema**

All event fields produces by the input are expected to be aligned with ECS.

resolves #60 

(depends on https://github.com/logstash-plugins/logstash-patterns-core/pull/262 and https://github.com/logstash-plugins/logstash-filter-grok/pull/162)