### PR TITLE
Change TCP reading mode to use the non-blocking method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.7.0
+  - Changed the TCP reading mode to use the non-blocking method [#75](https://github.com/logstash-plugins/logstash-input-syslog/pull/75)
+    It fixes the high CPU usage when TCP clients do not properly disconnect/send EOF.
+  - Fixed broken tests
+
 ## 3.6.0
   - Add support for ECS v8 as alias to v1 implementation [#68](https://github.com/logstash-plugins/logstash-input-syslog/pull/68)
 

--- a/logstash-input-syslog.gemspec
+++ b/logstash-input-syslog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-syslog'
-  s.version         = '3.6.0'
+  s.version         = '3.7.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads syslog messages as events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The plugin is not properly detecting client disconnections. It seems it keeps trying to read from closed sockets, making the CPU usage grow every time a client disconnects or send EOF.

The problem is happening on the [socket.each](https://github.com/logstash-plugins/logstash-input-syslog/blob/main/lib/logstash/inputs/syslog.rb#L235) method. When the client connection is closed, or it receives an EOF, the code expects it to raise an error (EOFError, ...), stopping the loop, closing the connection and removing it from the connection counter. Instead, it doesn't raise any error, and the CPU usage grows due to some internal issue.

The alternative solution is to change it to read using a non-blocking approach. The `read_nonblock` raises EOF/disconnect errors, making the existing code work properly.

This PR:

- Changed the TCP reading mode to use the non-blocking method (`read_nonblock`)
- Fixed all broken tests
   - Please hide the white spaces to compare as the indentation level changed
   - New tests are inside `tcp receiver` context
   - Essentially, there were no logic changes/refactoring/improvements on the existing tests, the idea was only to adapt them to work with the current `ecs_compatibility` matrix, as most of them were considering it was always disabled.
   - The `should properly handle the cef codec with a custom grok_pattern` was changed to what I believe is the correct usage of `syslog` with `cef` codec.


---
Closes: https://github.com/logstash-plugins/logstash-input-syslog/issues/74
Closes: https://github.com/logstash-plugins/logstash-input-syslog/issues/70