### PR TITLE
Set priority to 13 when grok fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.7.1
+  - Fix issue where the priority field was not being set correctly when grok failed [#76](https://github.com/logstash-plugins/logstash-input-syslog/pull/78)
+
 ## 3.7.0
   - Changed the TCP reading mode to use the non-blocking method [#75](https://github.com/logstash-plugins/logstash-input-syslog/pull/75)
     It fixes the high CPU usage when TCP clients do not properly disconnect/send EOF.

--- a/logstash-input-syslog.gemspec
+++ b/logstash-input-syslog.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-syslog'
-  s.version         = '3.7.0'
+  s.version         = '3.7.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads syslog messages as events"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/syslog_spec.rb
+++ b/spec/inputs/syslog_spec.rb
@@ -145,6 +145,7 @@ describe LogStash::Inputs::Syslog do
           event = LogStash::Event.new({ "message" => "hello world, this is not syslog RFC3164" })
           input.syslog_relay(event)
           expect( event.get("tags") ).to eql  ["_grokparsefailure_sysloginput"]
+          expect( event.get(priority_key) ).to eql 13
 
           syslog_event = LogStash::Event.new({ "message" => "<164>Oct 26 15:19:25 1.2.3.4 %ASA-4-106023: Deny udp src DRAC:10.1.2.3/43434" })
           input.syslog_relay(syslog_event)


### PR DESCRIPTION
Fixes: https://github.com/logstash-plugins/logstash-input-syslog/issues/77

There are two issues related to grok when it fails to parse the pattern.
1. Fail to lookup `_grokparsefailure` in `tags`
2. Fail to set `priority` to 13. 
   when the target priority field does not exist, it sets zero instead

This commit sets the priority to 13 when grok fails